### PR TITLE
Fix Mongo replica set configuration for local usage

### DIFF
--- a/backend-qrcode-menu/Dockerfile
+++ b/backend-qrcode-menu/Dockerfile
@@ -1,16 +1,13 @@
-ARG MONGO_VERSION
+ARG MONGO_VERSION=6.0
 
-FROM mongo:latest
+FROM mongo:${MONGO_VERSION}
 
 ENV MONGO_REPLICA_PORT=27017 \
     MONGO_REPLICA_HOST=localhost \
-    MONGO_COMMAND=mongo
+    MONGO_REPLICA_SET=rs0
 
-# we take over the default & start mongo in replica set mode in a background task
-ENTRYPOINT mongod --port $MONGO_REPLICA_PORT --replSet rs0 --bind_ip 0.0.0.0 & MONGOD_PID=$!; \
-    # we prepare the replica set with a single node and prepare the root user config
-    INIT_REPL_CMD="rs.initiate({ _id: 'rs0', members: [{ _id: 0, host: '$MONGO_REPLICA_HOST:$MONGO_REPLICA_PORT' }] })"; \
-    # we wait for the replica set to be ready and then submit the command just above
-    until ($MONGO_COMMAND admin --port $MONGO_REPLICA_PORT --eval "$INIT_REPL_CMD"); do sleep 1; done; \
-    # we are done but we keep the container by waiting on signals from the mongo task
-    echo "REPLICA SET ONLINE"; wait $MONGOD_PID;
+COPY docker-entrypoint.sh /usr/local/bin/docker-entrypoint.sh
+RUN chmod +x /usr/local/bin/docker-entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]
+CMD []

--- a/backend-qrcode-menu/docker-compose.yaml
+++ b/backend-qrcode-menu/docker-compose.yaml
@@ -16,15 +16,22 @@ services:
     restart: unless-stopped
 
   mongo:
-    image: mongo:4.4
+    build:
+      context: .
+      dockerfile: Dockerfile
     container_name: mongo_online_menu
-    command:
-      [
-        "bash",
-        "-c",
-        'mongod --replSet rs0 --bind_ip_all & sleep 5 && mongo --eval ''rs.initiate({_id:"rs0", members:[{_id:0, host:"mongo:27017"}]})'' && tail -f /dev/null',
-      ]
+    environment:
+      MONGO_REPLICA_HOST: localhost
+      MONGO_REPLICA_PORT: 27017
+      MONGO_REPLICA_SET: rs0
     ports:
       - "27017:27017"
     volumes:
       - ./data/mongo:/data/db
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "mongosh", "--host", "localhost", "--port", "27017", "--eval", "db.runCommand({ ping: 1 })"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 10s

--- a/backend-qrcode-menu/docker-entrypoint.sh
+++ b/backend-qrcode-menu/docker-entrypoint.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+set -euo pipefail
+
+MONGO_REPLICA_PORT="${MONGO_REPLICA_PORT:-27017}"
+MONGO_REPLICA_HOST="${MONGO_REPLICA_HOST:-localhost}"
+MONGO_REPLICA_SET="${MONGO_REPLICA_SET:-rs0}"
+
+mongod --replSet "${MONGO_REPLICA_SET}" --bind_ip_all --port "${MONGO_REPLICA_PORT}" "$@" &
+MONGOD_PID=$!
+
+cleanup() {
+  if kill -0 "${MONGOD_PID}" 2>/dev/null; then
+    kill "${MONGOD_PID}"
+    wait "${MONGOD_PID}" || true
+  fi
+}
+
+trap cleanup INT TERM
+
+if command -v mongosh >/dev/null 2>&1; then
+  MONGO_SHELL=(mongosh --quiet)
+else
+  MONGO_SHELL=(mongo --quiet)
+fi
+
+until "${MONGO_SHELL[@]}" --port "${MONGO_REPLICA_PORT}" --eval "db.runCommand({ ping: 1 })" >/dev/null 2>&1; do
+  sleep 1
+done
+
+read -r -d '' INIT_REPL_JS <<EOF_JS
+const config = {
+  _id: "${MONGO_REPLICA_SET}",
+  members: [{ _id: 0, host: "${MONGO_REPLICA_HOST}:${MONGO_REPLICA_PORT}" }],
+};
+try {
+  const status = rs.status();
+  if (status.ok !== 1) {
+    throw new Error(JSON.stringify(status));
+  }
+} catch (error) {
+  if (error.codeName === 'NotYetInitialized' || error.code === 94) {
+    rs.initiate(config);
+  } else if (error.codeName !== 'AlreadyInitialized' && error.code !== 23) {
+    throw error;
+  }
+}
+EOF_JS
+
+"${MONGO_SHELL[@]}" --port "${MONGO_REPLICA_PORT}" --eval "${INIT_REPL_JS}" >/dev/null
+
+tail --pid="${MONGOD_PID}" -f /dev/null


### PR DESCRIPTION
## Summary
- add a custom MongoDB entrypoint that initializes the replica set with a configurable host and port
- update the Dockerfile to rely on the entrypoint for local replica set development
- wire the docker-compose Mongo service to the new image and add a healthcheck for readiness

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910a68adf98832099d80a06d84e482f)