### PR TITLE
Refactor Mongo relations to use ObjectIds

### DIFF
--- a/backend-qrcode-menu/src/application/use-case/product/update-product.usecase.ts
+++ b/backend-qrcode-menu/src/application/use-case/product/update-product.usecase.ts
@@ -31,16 +31,31 @@ export class UpdateProductUseCase {
 
     const product = await this.productRepository.findOne(productId);
 
-    const update = {
-      ...product,
-      ...updateProductInput,
-      productIngredient:
-        productIngredientMany.length > 0 ? productIngredientMany : [],
-    };
+    const ingredients =
+      productIngredientMany.length > 0
+        ? productIngredientMany.map((ingredient) => ({
+            id: ingredient.id,
+            name: ingredient.name,
+            emoji: ingredient.emoji,
+            color: ingredient.color,
+            slug: ingredient.slug,
+          }))
+        : product.ingredients ?? [];
 
-    console.log('UPDATE:', update);
+    const updatedProduct = new ProductEntity(
+      updateProductInput.name ?? product.name,
+      updateProductInput.description ?? product.description,
+      updateProductInput.price ?? product.price,
+      updateProductInput.image ?? product.image,
+      updateProductInput.categoryId ?? product.categoryId,
+      product.id,
+      product.createdAt,
+      product.slug,
+      product.category,
+      ingredients,
+    );
 
-    return await this.productRepository.updateProduct(update as ProductEntity);
+    return await this.productRepository.updateProduct(updatedProduct);
   }
 }
 

--- a/backend-qrcode-menu/src/domain/entities/ingredient.entity.ts
+++ b/backend-qrcode-menu/src/domain/entities/ingredient.entity.ts
@@ -22,9 +22,7 @@ export class IngredientEntity {
     this.emoji = emoji;
     this.color = color;
     this.slug =
-      slug !== undefined || slug === ''
-        ? SlugEntity.create(name).toString()
-        : slug;
+      slug && slug.length > 0 ? slug : SlugEntity.create(name).toString();
     this.createdAt = createdAt ? new Date(createdAt) : new Date();
   }
 }

--- a/backend-qrcode-menu/src/domain/entities/product.entity.ts
+++ b/backend-qrcode-menu/src/domain/entities/product.entity.ts
@@ -16,7 +16,7 @@ export class ProductEntity {
     slug: string;
   };
 
-  productIngredient?: {
+  ingredients?: {
     id: string;
     name: string;
     emoji: string;
@@ -47,13 +47,11 @@ export class ProductEntity {
     this.description = description;
     this.price = price;
     this.image = image;
-    this.categoryId = new UniqueEntityId(categoryId).toString();
+    this.categoryId = categoryId;
     this.slug =
-      slug !== undefined || slug === ''
-        ? SlugEntity.create(name).toString()
-        : slug;
+      slug && slug.length > 0 ? slug : SlugEntity.create(name).toString();
     this.createdAt = createdAt ? new Date(createdAt) : new Date();
     this.category = category;
-    this.productIngredient = ingredients;
+    this.ingredients = ingredients ?? [];
   }
 }

--- a/backend-qrcode-menu/src/domain/mappers/category.mapper.ts
+++ b/backend-qrcode-menu/src/domain/mappers/category.mapper.ts
@@ -4,6 +4,7 @@ import {
   Category as CategoryPrisma,
 } from '@prisma/client';
 import { Category as CategoryMongo } from '@infra/database/mongo/schema/category.schema';
+import { Types } from 'mongoose';
 
 export class CategoryMapper {
   static toPersistent(
@@ -26,12 +27,20 @@ export class CategoryMapper {
     );
   }
 
-  static toMongo(categoryEntity: CategoryEntity): Partial<CategoryMongo> {
-    return {
-      id: categoryEntity.id,
+  static toMongo(
+    categoryEntity: CategoryEntity,
+  ): Partial<CategoryMongo> & { _id?: Types.ObjectId } {
+    const payload: Partial<CategoryMongo> & { _id?: Types.ObjectId } = {
       name: categoryEntity.name,
       slug: categoryEntity.slug,
+      created_at: categoryEntity.createdAt,
     };
+
+    if (categoryEntity.id) {
+      payload._id = new Types.ObjectId(categoryEntity.id);
+    }
+
+    return payload;
   }
 
   static fromMongo(
@@ -39,7 +48,7 @@ export class CategoryMapper {
   ): CategoryEntity {
     return new CategoryEntity(
       categoryMongo.name,
-      categoryMongo.id,
+      (categoryMongo as any)._id?.toString?.() ?? (categoryMongo as any).id,
       categoryMongo.created_at || new Date(),
       categoryMongo.slug,
     );

--- a/backend-qrcode-menu/src/domain/mappers/ingredient.mapper.ts
+++ b/backend-qrcode-menu/src/domain/mappers/ingredient.mapper.ts
@@ -1,6 +1,7 @@
 import { IngredientEntity } from '@domain/entities/ingredient.entity';
 import { Ingredient } from '@prisma/client';
 import { Ingredient as IngredientMongo } from '@infra/database/mongo/schema/ingredient.schema';
+import { Types } from 'mongoose';
 
 export class IngredientMapper {
   static toPersistent(ingredient: IngredientEntity): Ingredient {
@@ -25,14 +26,22 @@ export class IngredientMapper {
     );
   }
 
-  static toMongo(ingredient: IngredientEntity): Partial<IngredientMongo> {
-    return {
-      id: ingredient.id,
+  static toMongo(
+    ingredient: IngredientEntity,
+  ): Partial<IngredientMongo> & { _id?: Types.ObjectId } {
+    const payload: Partial<IngredientMongo> & { _id?: Types.ObjectId } = {
       color: ingredient.color,
       emoji: ingredient.emoji,
       name: ingredient.name,
       slug: ingredient.slug,
+      created_at: ingredient.createdAt,
     };
+
+    if (ingredient.id) {
+      payload._id = new Types.ObjectId(ingredient.id);
+    }
+
+    return payload;
   }
 
   static fromMongo(
@@ -42,7 +51,7 @@ export class IngredientMapper {
       ingredientMongo.emoji,
       ingredientMongo.color,
       ingredientMongo.name,
-      ingredientMongo.id,
+      (ingredientMongo as any)._id?.toString?.() ?? (ingredientMongo as any).id,
       ingredientMongo.created_at || new Date(),
       ingredientMongo.slug,
     );

--- a/backend-qrcode-menu/src/domain/mappers/product.mapper.ts
+++ b/backend-qrcode-menu/src/domain/mappers/product.mapper.ts
@@ -95,7 +95,12 @@ export class ProductMapper {
   static fromMongo(
     productMongo: ProductMongo & {
       created_at?: Date;
-      category?: { _id?: Types.ObjectId; name: string; slug: string };
+      category?: {
+        _id?: Types.ObjectId;
+        id?: string;
+        name: string;
+        slug: string;
+      };
       ingredients?: (
         | {
             _id?: Types.ObjectId;

--- a/backend-qrcode-menu/src/domain/mappers/product.mapper.ts
+++ b/backend-qrcode-menu/src/domain/mappers/product.mapper.ts
@@ -1,6 +1,7 @@
 import { ProductEntity } from '@domain/entities/product.entity';
 import { Products, Prisma } from '@prisma/client';
 import { Product as ProductMongo } from '@infra/database/mongo/schema/product.schema';
+import { Types } from 'mongoose';
 
 export class ProductMapper {
   static toPersistent(product: ProductEntity): Products {
@@ -53,61 +54,115 @@ export class ProductMapper {
     );
   }
 
-  static toMongo(product: ProductEntity): Partial<ProductMongo> {
-    const productIngredients = product.productIngredient ?? [];
+  static toMongo(
+    product: ProductEntity,
+  ): Partial<ProductMongo> & { _id?: Types.ObjectId } {
+    const ingredients = product.ingredients ?? [];
+    const categoryObjectId = Types.ObjectId.isValid(product.categoryId)
+      ? new Types.ObjectId(product.categoryId)
+      : null;
 
-    return {
-      id: product.id,
-      categoryId: product.categoryId,
+    if (!categoryObjectId) {
+      throw new Error(`Invalid category identifier: ${product.categoryId}`);
+    }
+
+    const ingredientObjectIds = ingredients.map((ingredient) => {
+      if (!Types.ObjectId.isValid(ingredient.id)) {
+        throw new Error(`Invalid ingredient identifier: ${ingredient.id}`);
+      }
+
+      return new Types.ObjectId(ingredient.id);
+    });
+
+    const payload: Partial<ProductMongo> & { _id?: Types.ObjectId } = {
       name: product.name,
       description: product.description,
       image: product.image,
       price: product.price,
       slug: product.slug,
       created_at: product.createdAt,
-
-      productIngredient: productIngredients.map((ingredient: any) => ({
-        id: ingredient.id,
-        name: ingredient.name,
-        emoji: ingredient.emoji,
-        color: ingredient.color,
-        slug: ingredient.slug,
-      })),
+      category: categoryObjectId,
+      ingredients: ingredientObjectIds,
     };
+
+    if (product.id) {
+      payload._id = new Types.ObjectId(product.id);
+    }
+
+    return payload;
   }
 
   static fromMongo(
     productMongo: ProductMongo & {
       created_at?: Date;
-      category?: { name: string; slug: string };
-      productIngredient?: {
+      category?: { _id?: Types.ObjectId; name: string; slug: string };
+      ingredients?: (
+        | {
+            _id?: Types.ObjectId;
+            id?: string;
+            name: string;
+            emoji: string;
+            color: string;
+            slug: string;
+          }
+        | Types.ObjectId
+      )[];
+    },
+  ): ProductEntity {
+    const ingredients = (productMongo.ingredients ?? [])
+      .map((ingredient) => {
+        if (
+          ingredient instanceof Types.ObjectId ||
+          ingredient === null ||
+          ingredient === undefined
+        ) {
+          return null;
+        }
+
+        return {
+          id:
+            'id' in ingredient && ingredient.id
+              ? ingredient.id
+              : ingredient._id?.toString() ?? '',
+          name: ingredient.name,
+          emoji: ingredient.emoji,
+          color: ingredient.color,
+          slug: ingredient.slug,
+        };
+      })
+      .filter((ingredient): ingredient is {
         id: string;
         name: string;
         emoji: string;
         color: string;
         slug: string;
-      }[];
-    },
-  ): ProductEntity {
-    const ingredients =
-      productMongo.productIngredient?.map((pi) => ({
-        id: pi.id,
-        name: pi.name,
-        emoji: pi.emoji,
-        color: pi.color,
-        slug: pi.slug,
-      })) ?? [];
+      } => Boolean(ingredient));
+
+    const category = productMongo.category;
+    const mappedCategory =
+      category && !(category instanceof Types.ObjectId)
+        ? {
+            name: category.name,
+            slug: category.slug,
+          }
+        : undefined;
+
+    const categoryId = category instanceof Types.ObjectId
+      ? category.toHexString()
+      : category && 'id' in category && category.id
+        ? (category as { id: string }).id
+        : (productMongo as any).categoryId ?? category?._id?.toHexString() ?? '';
 
     return new ProductEntity(
       productMongo.name,
       productMongo.description,
       productMongo.price,
       productMongo.image,
-      productMongo.categoryId,
-      productMongo.id,
+      categoryId,
+      (productMongo as any)._id?.toString?.() ?? (productMongo as any).id,
       productMongo.created_at || new Date(),
       productMongo.slug,
-      productMongo.category,
+      mappedCategory,
       ingredients,
     );
   }

--- a/backend-qrcode-menu/src/domain/value-objects/unique-entity-id.value.ts
+++ b/backend-qrcode-menu/src/domain/value-objects/unique-entity-id.value.ts
@@ -1,10 +1,10 @@
-import { randomUUID } from 'node:crypto';
+import { Types } from 'mongoose';
 
 export class UniqueEntityId {
   private readonly _value: string;
 
   constructor(id?: string) {
-    this._value = id ?? randomUUID();
+    this._value = id ?? new Types.ObjectId().toHexString();
   }
 
   get value(): string {

--- a/backend-qrcode-menu/src/infra/database/mongo/repository/category-mongo.repository.ts
+++ b/backend-qrcode-menu/src/infra/database/mongo/repository/category-mongo.repository.ts
@@ -22,7 +22,10 @@ export class CategoryMongoRepository implements CategoryRepository {
   }
 
   async findAll(): Promise<CategoryEntity[]> {
-    const categories = await this.categoryModel.find().sort(createdAt).lean();
+    const categories = await this.categoryModel
+      .find()
+      .sort({ created_at: -1 })
+      .lean();
     return categories.map((category) =>
       CategoryMapper.fromMongo(
         category as CategoryMongo & { created_at?: Date },
@@ -31,7 +34,7 @@ export class CategoryMongoRepository implements CategoryRepository {
   }
   async deleteCategory(categoryId: string): Promise<void | ErrorMessage> {
     const category = await this.categoryModel
-      .findOne({ id: categoryId })
+      .findById(categoryId)
       .lean();
 
     if (!category) {
@@ -49,11 +52,11 @@ export class CategoryMongoRepository implements CategoryRepository {
       };
     }
 
-    await this.categoryModel.deleteOne({ id: categoryId });
+    await this.categoryModel.deleteOne({ _id: categoryId });
   }
   async findCategory(categoryId: string): Promise<CategoryEntity> {
     const category = await this.categoryModel
-      .findOne({ id: categoryId })
+      .findById(categoryId)
       .lean();
 
     if (!category) {
@@ -66,8 +69,8 @@ export class CategoryMongoRepository implements CategoryRepository {
   }
   async updateCategory(data: CategoryEntity): Promise<CategoryEntity> {
     const updatedCategory = await this.categoryModel
-      .findOneAndUpdate(
-        { id: data.id },
+      .findByIdAndUpdate(
+        data.id,
         {
           $set: {
             name: data.name,

--- a/backend-qrcode-menu/src/infra/database/mongo/repository/ingredient-mongo.repository.ts
+++ b/backend-qrcode-menu/src/infra/database/mongo/repository/ingredient-mongo.repository.ts
@@ -5,6 +5,7 @@ import { Injectable } from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { Model } from 'mongoose';
 import { Ingredient as IngredientMongo } from '../schema/ingredient.schema';
+import { toObjectId } from '@infra/utils/objectid-converter.util';
 
 @Injectable()
 export class IngredientMongoRepository implements IngredientRepository {
@@ -64,9 +65,9 @@ export class IngredientMongoRepository implements IngredientRepository {
   }
 
   async findId(ingredientId: string): Promise<IngredientEntity> {
-    const ingredientDoc = await this.ingredientModel
-      .findById(ingredientId)
-      .lean();
+    const id = toObjectId(ingredientId);
+    console.log('Finding ingredient with ID:', id);
+    const ingredientDoc = await this.ingredientModel.findById(id).lean();
 
     if (!ingredientDoc) {
       throw new Error(`Ingredient with ID ${ingredientId} not found`);

--- a/backend-qrcode-menu/src/infra/database/mongo/repository/ingredient-mongo.repository.ts
+++ b/backend-qrcode-menu/src/infra/database/mongo/repository/ingredient-mongo.repository.ts
@@ -65,22 +65,15 @@ export class IngredientMongoRepository implements IngredientRepository {
 
   async findId(ingredientId: string): Promise<IngredientEntity> {
     const ingredientDoc = await this.ingredientModel
-      .findOne({ id: ingredientId })
+      .findById(ingredientId)
       .lean();
 
     if (!ingredientDoc) {
       throw new Error(`Ingredient with ID ${ingredientId} not found`);
     }
 
-    const ingredientEntity = new IngredientEntity(
-      ingredientDoc.emoji,
-      ingredientDoc.color,
-      ingredientDoc.name,
-      ingredientDoc.id,
-      ingredientDoc.created_at || new Date(),
-      ingredientDoc.slug,
+    return IngredientMapper.fromMongo(
+      ingredientDoc as IngredientMongo & { created_at?: Date },
     );
-
-    return ingredientEntity;
   }
 }

--- a/backend-qrcode-menu/src/infra/database/mongo/schema/category.schema.ts
+++ b/backend-qrcode-menu/src/infra/database/mongo/schema/category.schema.ts
@@ -2,18 +2,14 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document, Types } from 'mongoose';
 
-import { Product } from './product.schema';
-
 @Schema({
   collection: 'categories',
   timestamps: { createdAt: 'created_at', updatedAt: false },
 })
 export class Category extends Document {
-  @Prop({
-    type: String,
-    default: () => new Types.UUID().toString(),
-    unique: true,
-  })
+  @Prop({ type: Types.ObjectId, default: () => new Types.ObjectId() })
+  declare _id: Types.ObjectId;
+
   @Prop({ required: true })
   name: string;
 
@@ -23,8 +19,11 @@ export class Category extends Document {
   @Prop()
   created_at: Date;
 
-  @Prop({ type: [{ type: Types.ObjectId, ref: 'Product' }] })
-  products: Product[];
+  @Prop({
+    type: [{ type: Types.ObjectId, ref: 'Product' }],
+    default: [],
+  })
+  products: Types.ObjectId[];
 }
 
 export const CategorySchema = SchemaFactory.createForClass(Category);

--- a/backend-qrcode-menu/src/infra/database/mongo/schema/ingredient.schema.ts
+++ b/backend-qrcode-menu/src/infra/database/mongo/schema/ingredient.schema.ts
@@ -1,18 +1,13 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document, Types } from 'mongoose';
-import { ProductIngredient } from './product-ingredient.schema';
 
 @Schema({
   collection: 'ingredients',
   timestamps: { createdAt: 'created_at', updatedAt: false },
 })
 export class Ingredient extends Document {
-  @Prop({
-    type: String,
-    default: () => new Types.UUID().toString(),
-    unique: true,
-  })
-  declare id: string;
+  @Prop({ type: Types.ObjectId, default: () => new Types.ObjectId() })
+  declare _id: Types.ObjectId;
 
   @Prop({ required: true })
   emoji: string;
@@ -29,8 +24,11 @@ export class Ingredient extends Document {
   @Prop()
   created_at: Date;
 
-  @Prop({ type: [{ type: Types.ObjectId, ref: 'ProductIngredient' }] })
-  productIngredient: ProductIngredient[];
+  @Prop({
+    type: [{ type: Types.ObjectId, ref: 'Product' }],
+    default: [],
+  })
+  products: Types.ObjectId[];
 }
 
 export const IngredientSchema = SchemaFactory.createForClass(Ingredient);

--- a/backend-qrcode-menu/src/infra/database/mongo/schema/product.schema.ts
+++ b/backend-qrcode-menu/src/infra/database/mongo/schema/product.schema.ts
@@ -1,18 +1,15 @@
 import { Prop, Schema, SchemaFactory } from '@nestjs/mongoose';
 import { Document, Types } from 'mongoose';
 import { Category } from './category.schema';
+import { Ingredient } from './ingredient.schema';
 
 @Schema({
   collection: 'products',
   timestamps: { createdAt: 'created_at', updatedAt: false },
 })
 export class Product extends Document {
-  @Prop({
-    type: String,
-    default: () => new Types.UUID().toString(),
-    unique: true,
-  })
-  declare id: string;
+  @Prop({ type: Types.ObjectId, default: () => new Types.ObjectId() })
+  declare _id: Types.ObjectId;
 
   @Prop({ required: true })
   name: string;
@@ -29,34 +26,17 @@ export class Product extends Document {
   @Prop({ required: true, unique: true })
   slug: string;
 
-  @Prop({ type: String, ref: 'Category', required: true })
-  categoryId: string;
-
-  @Prop({ type: Types.ObjectId, ref: 'Category' })
-  category: Category;
+  @Prop({ type: Types.ObjectId, ref: Category.name, required: true })
+  category: Types.ObjectId | Category;
 
   @Prop()
   created_at: Date;
 
   @Prop({
-    type: [
-      {
-        id: { type: String, required: true },
-        name: { type: String, required: true },
-        emoji: { type: String, required: true },
-        color: { type: String, required: true },
-        slug: { type: String, required: true },
-      },
-    ],
+    type: [{ type: Types.ObjectId, ref: Ingredient.name }],
     default: [],
   })
-  productIngredient: {
-    id: string;
-    name: string;
-    emoji: string;
-    color: string;
-    slug: string;
-  }[];
+  ingredients: (Types.ObjectId | Ingredient)[];
 }
 
 export const ProductSchema = SchemaFactory.createForClass(Product);

--- a/backend-qrcode-menu/src/infra/modules/database.module.ts
+++ b/backend-qrcode-menu/src/infra/modules/database.module.ts
@@ -65,8 +65,18 @@ const repositoryProviders =
           useFactory: (
             productModel: Model<Product>,
             categoryModel: Model<Category>,
-          ) => new ProductMongoRepository(productModel, categoryModel),
-          inject: [getModelToken(Product.name), getModelToken(Category.name)],
+            ingredientModel: Model<Ingredient>,
+          ) =>
+            new ProductMongoRepository(
+              productModel,
+              categoryModel,
+              ingredientModel,
+            ),
+          inject: [
+            getModelToken(Product.name),
+            getModelToken(Category.name),
+            getModelToken(Ingredient.name),
+          ],
         },
         {
           provide: INGREDIENT_REPOSITORY,

--- a/backend-qrcode-menu/src/infra/utils/objectid-converter.util.ts
+++ b/backend-qrcode-menu/src/infra/utils/objectid-converter.util.ts
@@ -1,0 +1,8 @@
+import { Types } from 'mongoose';
+
+export const toObjectId = (id: string): Types.ObjectId => {
+  if (!Types.ObjectId.isValid(id)) {
+    throw new Error(`Invalid ObjectId: ${id}`);
+  }
+  return new Types.ObjectId(id);
+};

--- a/backend-qrcode-menu/test/domain/unique-entity-id.spec.ts
+++ b/backend-qrcode-menu/test/domain/unique-entity-id.spec.ts
@@ -1,11 +1,12 @@
 import { UniqueEntityId } from '@domain/value-objects/unique-entity-id.value';
 
 describe('UniqueEntityId VO', () => {
-  it('deve gerar um novo UUID quando nenhum id for passado', () => {
+  it('deve gerar um novo ObjectId quando nenhum id for passado', () => {
     const id = new UniqueEntityId();
     expect(id.value).toBeDefined();
     expect(typeof id.value).toBe('string');
-    expect(id.value).toHaveLength(36);
+    expect(id.value).toHaveLength(24);
+    expect(id.value).toMatch(/^[a-f\d]{24}$/i);
   });
 
   it('deve aceitar um id existente', () => {


### PR DESCRIPTION
## Summary
- switch the unique entity id value object and domain entities to Mongo-style ObjectId identifiers and clean slug handling
- remodel product, ingredient, and category schemas/repositories to store ObjectId relationships and populate category/ingredient data
- adjust the product update flow, mappers, and supporting tests to work with the new ingredient references

## Testing
- yarn test --runInBand

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6910b16311048320b04dfd0b51830b72)