### PR TITLE
feat: connect dashboard menu with list views

### DIFF
--- a/dashboard-qrcode-menu/src/components/app-sidebar.tsx
+++ b/dashboard-qrcode-menu/src/components/app-sidebar.tsx
@@ -3,15 +3,14 @@
 import * as React from "react";
 import {
   AudioWaveform,
-  BookOpen,
-  Bot,
   Command,
   Frame,
   GalleryVerticalEnd,
   Map,
   PieChart,
-  Settings2,
-  SquareTerminal,
+  Tags,
+  Utensils,
+  Wheat,
 } from "lucide-react";
 
 import { NavMain } from "@/components/nav-main";
@@ -27,6 +26,8 @@ import {
 } from "@/components/ui/sidebar";
 
 // This is sample data.
+export type DashboardSection = "products" | "categories" | "ingredients";
+
 const data = {
   user: {
     name: "shadcn",
@@ -52,89 +53,19 @@ const data = {
   ],
   navMain: [
     {
-      title: "Playground",
-      url: "#",
-      icon: SquareTerminal,
-      isActive: true,
-      items: [
-        {
-          title: "History",
-          url: "#",
-        },
-        {
-          title: "Starred",
-          url: "#",
-        },
-        {
-          title: "Settings",
-          url: "#",
-        },
-      ],
+      title: "Lista de produtos",
+      value: "products" satisfies DashboardSection,
+      icon: Utensils,
     },
     {
-      title: "Models",
-      url: "#",
-      icon: Bot,
-      items: [
-        {
-          title: "Genesis",
-          url: "#",
-        },
-        {
-          title: "Explorer",
-          url: "#",
-        },
-        {
-          title: "Quantum",
-          url: "#",
-        },
-      ],
+      title: "Lista de categorias",
+      value: "categories" satisfies DashboardSection,
+      icon: Tags,
     },
     {
-      title: "Documentation",
-      url: "#",
-      icon: BookOpen,
-      items: [
-        {
-          title: "Introduction",
-          url: "#",
-        },
-        {
-          title: "Get Started",
-          url: "#",
-        },
-        {
-          title: "Tutorials",
-          url: "#",
-        },
-        {
-          title: "Changelog",
-          url: "#",
-        },
-      ],
-    },
-    {
-      title: "Settings",
-      url: "#",
-      icon: Settings2,
-      items: [
-        {
-          title: "General",
-          url: "#",
-        },
-        {
-          title: "Team",
-          url: "#",
-        },
-        {
-          title: "Billing",
-          url: "#",
-        },
-        {
-          title: "Limits",
-          url: "#",
-        },
-      ],
+      title: "Lista de ingredientes",
+      value: "ingredients" satisfies DashboardSection,
+      icon: Wheat,
     },
   ],
   projects: [
@@ -156,14 +87,27 @@ const data = {
   ],
 };
 
-export function AppSidebar({ ...props }: React.ComponentProps<typeof Sidebar>) {
+interface AppSidebarProps extends React.ComponentProps<typeof Sidebar> {
+  activeSection: DashboardSection;
+  onSelectSection: (section: DashboardSection) => void;
+}
+
+export function AppSidebar({
+  activeSection,
+  onSelectSection,
+  ...props
+}: AppSidebarProps) {
   return (
     <Sidebar collapsible="icon" {...props}>
       <SidebarHeader>
         <TeamSwitcher teams={data.teams} />
       </SidebarHeader>
       <SidebarContent>
-        <NavMain items={data.navMain} />
+        <NavMain
+          items={data.navMain}
+          activeValue={activeSection}
+          onSelect={(value) => onSelectSection(value as DashboardSection)}
+        />
         <NavProjects projects={data.projects} />
       </SidebarContent>
       <SidebarFooter>

--- a/dashboard-qrcode-menu/src/components/nav-main.tsx
+++ b/dashboard-qrcode-menu/src/components/nav-main.tsx
@@ -1,69 +1,41 @@
-import { ChevronRight, type LucideIcon } from "lucide-react"
+import { type LucideIcon } from "lucide-react"
 
-import {
-  Collapsible,
-  CollapsibleContent,
-  CollapsibleTrigger,
-} from "@/components/ui/collapsible"
 import {
   SidebarGroup,
   SidebarGroupLabel,
   SidebarMenu,
   SidebarMenuButton,
   SidebarMenuItem,
-  SidebarMenuSub,
-  SidebarMenuSubButton,
-  SidebarMenuSubItem,
 } from "@/components/ui/sidebar"
 
-export function NavMain({
-  items,
-}: {
-  items: {
-    title: string
-    url: string
-    icon?: LucideIcon
-    isActive?: boolean
-    items?: {
-      title: string
-      url: string
-    }[]
-  }[]
-}) {
+type NavMainItem = {
+  title: string
+  value: string
+  icon?: LucideIcon
+}
+
+type NavMainProps = {
+  items: NavMainItem[]
+  activeValue?: string
+  onSelect?: (value: string) => void
+}
+
+export function NavMain({ items, activeValue, onSelect }: NavMainProps) {
   return (
     <SidebarGroup>
-      <SidebarGroupLabel>Platform</SidebarGroupLabel>
+      <SidebarGroupLabel>Listas</SidebarGroupLabel>
       <SidebarMenu>
         {items.map((item) => (
-          <Collapsible
-            key={item.title}
-            asChild
-            defaultOpen={item.isActive}
-            className="group/collapsible"
-          >
-            <SidebarMenuItem>
-              <CollapsibleTrigger asChild>
-                <SidebarMenuButton tooltip={item.title}>
-                  {item.icon && <item.icon />}
-                  <span>{item.title}</span>
-                  <ChevronRight className="ml-auto transition-transform duration-200 group-data-[state=open]/collapsible:rotate-90" />
-                </SidebarMenuButton>
-              </CollapsibleTrigger>
-              <CollapsibleContent>
-                <SidebarMenuSub>
-                  {item.items?.map((subItem) => (
-                    <SidebarMenuSubItem key={subItem.title}>
-                      <SidebarMenuSubButton asChild>
-                        <a href={subItem.url}>
-                          <span>{subItem.title}</span>
-                        </a>
-                      </SidebarMenuSubButton>
-                    </SidebarMenuSubItem>
-                  ))}
-                </SidebarMenuSub>
-              </CollapsibleContent>
-            </SidebarMenuItem>
-          </Collapsible>
+          <SidebarMenuItem key={item.value}>
+            <SidebarMenuButton
+              isActive={item.value === activeValue}
+              onClick={() => onSelect?.(item.value)}
+              tooltip={item.title}
+            >
+              {item.icon && <item.icon />}
+              <span>{item.title}</span>
+            </SidebarMenuButton>
+          </SidebarMenuItem>
         ))}
       </SidebarMenu>
     </SidebarGroup>

--- a/dashboard-qrcode-menu/src/components/table-generics.tsx
+++ b/dashboard-qrcode-menu/src/components/table-generics.tsx
@@ -33,45 +33,62 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-const data: Payment[] = [
+
+type ProductStatus = "available" | "unavailable" | "out-of-stock";
+
+type Product = {
+  id: string;
+  name: string;
+  category: string;
+  price: number;
+  status: ProductStatus;
+};
+
+const products: Product[] = [
   {
-    id: "m5gr84i9",
-    amount: 316,
-    status: "success",
-    email: "ken99@example.com",
+    id: "prod-01",
+    name: "Hambúrguer Clássico",
+    category: "Lanches",
+    price: 29.9,
+    status: "available",
   },
   {
-    id: "3u1reuv4",
-    amount: 242,
-    status: "success",
-    email: "Abe45@example.com",
+    id: "prod-02",
+    name: "Pizza Margherita",
+    category: "Pizzas",
+    price: 42.5,
+    status: "available",
   },
   {
-    id: "derv1ws0",
-    amount: 837,
-    status: "processing",
-    email: "Monserrat44@example.com",
+    id: "prod-03",
+    name: "Ceviche de Tilápia",
+    category: "Entradas",
+    price: 35.0,
+    status: "out-of-stock",
   },
   {
-    id: "5kma53ae",
-    amount: 874,
-    status: "success",
-    email: "Silas22@example.com",
+    id: "prod-04",
+    name: "Suco Detox",
+    category: "Bebidas",
+    price: 18.9,
+    status: "available",
   },
   {
-    id: "bhqecj4p",
-    amount: 721,
-    status: "failed",
-    email: "carmella@example.com",
+    id: "prod-05",
+    name: "Brownie com Sorvete",
+    category: "Sobremesas",
+    price: 22.9,
+    status: "unavailable",
   },
 ];
-export type Payment = {
-  id: string;
-  amount: number;
-  status: "pending" | "processing" | "success" | "failed";
-  email: string;
+
+const statusLabel: Record<ProductStatus, string> = {
+  available: "Disponível",
+  unavailable: "Indisponível",
+  "out-of-stock": "Esgotado",
 };
-export const columns: ColumnDef<Payment>[] = [
+
+export const columns: ColumnDef<Product>[] = [
   {
     id: "select",
     header: ({ table }) => (
@@ -81,84 +98,93 @@ export const columns: ColumnDef<Payment>[] = [
           (table.getIsSomePageRowsSelected() && "indeterminate")
         }
         onCheckedChange={(value) => table.toggleAllPageRowsSelected(!!value)}
-        aria-label="Select all"
+        aria-label="Selecionar todos"
       />
     ),
     cell: ({ row }) => (
       <Checkbox
         checked={row.getIsSelected()}
         onCheckedChange={(value) => row.toggleSelected(!!value)}
-        aria-label="Select row"
+        aria-label="Selecionar linha"
       />
     ),
     enableSorting: false,
     enableHiding: false,
   },
   {
-    accessorKey: "status",
-    header: "Status",
+    accessorKey: "name",
+    header: ({ column }) => (
+      <Button
+        variant="ghost"
+        onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
+      >
+        Produto
+        <ArrowUpDown className="ml-2 h-4 w-4" />
+      </Button>
+    ),
     cell: ({ row }) => (
-      <div className="capitalize">{row.getValue("status")}</div>
+      <div className="font-medium">{row.getValue("name")}</div>
     ),
   },
   {
-    accessorKey: "email",
-    header: ({ column }) => {
-      return (
-        <Button
-          variant="ghost"
-          onClick={() => column.toggleSorting(column.getIsSorted() === "asc")}
-        >
-          Email
-          <ArrowUpDown />
-        </Button>
-      );
-    },
-    cell: ({ row }) => <div className="lowercase">{row.getValue("email")}</div>,
+    accessorKey: "category",
+    header: "Categoria",
+    cell: ({ row }) => (
+      <div className="text-muted-foreground">{row.getValue("category")}</div>
+    ),
   },
   {
-    accessorKey: "amount",
-    header: () => <div className="text-right">Amount</div>,
+    accessorKey: "price",
+    header: () => <div className="text-right">Preço</div>,
     cell: ({ row }) => {
-      const amount = parseFloat(row.getValue("amount"));
-      // Format the amount as a dollar amount
-      const formatted = new Intl.NumberFormat("en-US", {
+      const amount = parseFloat(row.getValue("price"));
+      const formatted = new Intl.NumberFormat("pt-BR", {
         style: "currency",
-        currency: "USD",
+        currency: "BRL",
       }).format(amount);
       return <div className="text-right font-medium">{formatted}</div>;
     },
   },
   {
+    accessorKey: "status",
+    header: "Status",
+    cell: ({ row }) => (
+      <div className="text-muted-foreground">
+        {statusLabel[row.getValue("status") as ProductStatus]}
+      </div>
+    ),
+  },
+  {
     id: "actions",
     enableHiding: false,
     cell: ({ row }) => {
-      const payment = row.original;
+      const product = row.original;
       return (
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button variant="ghost" className="h-8 w-8 p-0">
-              <span className="sr-only">Open menu</span>
+              <span className="sr-only">Abrir menu</span>
               <MoreHorizontal />
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
-            <DropdownMenuLabel>Actions</DropdownMenuLabel>
+            <DropdownMenuLabel>Ações</DropdownMenuLabel>
             <DropdownMenuItem
-              onClick={() => navigator.clipboard.writeText(payment.id)}
+              onClick={() => navigator.clipboard.writeText(product.id)}
             >
-              Copy payment ID
+              Copiar ID do produto
             </DropdownMenuItem>
             <DropdownMenuSeparator />
-            <DropdownMenuItem>View customer</DropdownMenuItem>
-            <DropdownMenuItem>View payment details</DropdownMenuItem>
+            <DropdownMenuItem>Editar produto</DropdownMenuItem>
+            <DropdownMenuItem>Ver detalhes</DropdownMenuItem>
           </DropdownMenuContent>
         </DropdownMenu>
       );
     },
   },
 ];
-export function DataTableDemo() {
+
+export function TableProducts() {
   const [sorting, setSorting] = React.useState<SortingState>([]);
   const [columnFilters, setColumnFilters] = React.useState<ColumnFiltersState>(
     []
@@ -166,8 +192,9 @@ export function DataTableDemo() {
   const [columnVisibility, setColumnVisibility] =
     React.useState<VisibilityState>({});
   const [rowSelection, setRowSelection] = React.useState({});
+
   const table = useReactTable({
-    data,
+    data: products,
     columns,
     onSortingChange: setSorting,
     onColumnFiltersChange: setColumnFilters,
@@ -184,21 +211,22 @@ export function DataTableDemo() {
       rowSelection,
     },
   });
+
   return (
     <div className="w-full">
       <div className="flex items-center py-4">
         <Input
-          placeholder="Filter emails..."
-          value={(table.getColumn("email")?.getFilterValue() as string) ?? ""}
+          placeholder="Filtrar por produto..."
+          value={(table.getColumn("name")?.getFilterValue() as string) ?? ""}
           onChange={(event) =>
-            table.getColumn("email")?.setFilterValue(event.target.value)
+            table.getColumn("name")?.setFilterValue(event.target.value)
           }
           className="max-w-sm"
         />
         <DropdownMenu>
           <DropdownMenuTrigger asChild>
             <Button variant="outline" className="ml-auto">
-              Columns <ChevronDown />
+              Colunas <ChevronDown />
             </Button>
           </DropdownMenuTrigger>
           <DropdownMenuContent align="end">
@@ -265,7 +293,7 @@ export function DataTableDemo() {
                   colSpan={columns.length}
                   className="h-24 text-center"
                 >
-                  No results.
+                  Nenhum resultado encontrado.
                 </TableCell>
               </TableRow>
             )}
@@ -274,8 +302,8 @@ export function DataTableDemo() {
       </div>
       <div className="flex items-center justify-end space-x-2 py-4">
         <div className="text-muted-foreground flex-1 text-sm">
-          {table.getFilteredSelectedRowModel().rows.length} of{" "}
-          {table.getFilteredRowModel().rows.length} row(s) selected.
+          {table.getFilteredSelectedRowModel().rows.length} de {" "}
+          {table.getFilteredRowModel().rows.length} linha(s) selecionadas.
         </div>
         <div className="space-x-2">
           <Button
@@ -284,7 +312,7 @@ export function DataTableDemo() {
             onClick={() => table.previousPage()}
             disabled={!table.getCanPreviousPage()}
           >
-            Previous
+            Anterior
           </Button>
           <Button
             variant="outline"
@@ -292,7 +320,7 @@ export function DataTableDemo() {
             onClick={() => table.nextPage()}
             disabled={!table.getCanNextPage()}
           >
-            Next
+            Próximo
           </Button>
         </div>
       </div>

--- a/dashboard-qrcode-menu/src/components/table-ingredients.tsx
+++ b/dashboard-qrcode-menu/src/components/table-ingredients.tsx
@@ -1,0 +1,72 @@
+"use client";
+
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from "@/components/ui/table";
+
+const ingredients = [
+  {
+    name: "Tomate",
+    quantity: "5 kg",
+    supplier: "Horta da Vila",
+    status: "Fresco",
+  },
+  {
+    name: "Queijo Muçarela",
+    quantity: "3 kg",
+    supplier: "Laticínios Serra Azul",
+    status: "Repor em breve",
+  },
+  {
+    name: "Alface",
+    quantity: "2 maços",
+    supplier: "Horta da Vila",
+    status: "Fresco",
+  },
+  {
+    name: "Carne Angus",
+    quantity: "8 kg",
+    supplier: "Empório das Carnes",
+    status: "Em estoque",
+  },
+  {
+    name: "Batata",
+    quantity: "10 kg",
+    supplier: "Distribuidora Central",
+    status: "Fresco",
+  },
+];
+
+export function TableIngredients() {
+  return (
+    <div className="overflow-hidden rounded-md border">
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Ingrediente</TableHead>
+            <TableHead>Quantidade</TableHead>
+            <TableHead>Fornecedor</TableHead>
+            <TableHead>Status</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {ingredients.map((ingredient) => (
+            <TableRow key={ingredient.name}>
+              <TableCell className="font-medium">{ingredient.name}</TableCell>
+              <TableCell>{ingredient.quantity}</TableCell>
+              <TableCell>{ingredient.supplier}</TableCell>
+              <TableCell className="text-muted-foreground">
+                {ingredient.status}
+              </TableCell>
+            </TableRow>
+          ))}
+        </TableBody>
+      </Table>
+    </div>
+  );
+}

--- a/dashboard-qrcode-menu/src/pages/dashboard/index.tsx
+++ b/dashboard-qrcode-menu/src/pages/dashboard/index.tsx
@@ -1,7 +1,9 @@
-import { AppSidebar } from "@/components/app-sidebar";
-import { TableCategory } from "@/components/table-categories";
+import { useMemo, useState } from "react";
 
-import { DataTableDemo } from "@/components/table-generics";
+import { AppSidebar, type DashboardSection } from "@/components/app-sidebar";
+import { TableCategory } from "@/components/table-categories";
+import { TableProducts } from "@/components/table-generics";
+import { TableIngredients } from "@/components/table-ingredients";
 import {
   Breadcrumb,
   BreadcrumbItem,
@@ -18,9 +20,27 @@ import {
 } from "@/components/ui/sidebar";
 
 export default function Dashboard() {
+  const [activeSection, setActiveSection] = useState<DashboardSection>(
+    "products",
+  );
+
+  const breadcrumbLabel = useMemo(() => {
+    switch (activeSection) {
+      case "categories":
+        return "Lista de categorias";
+      case "ingredients":
+        return "Lista de ingredientes";
+      default:
+        return "Lista de produtos";
+    }
+  }, [activeSection]);
+
   return (
     <SidebarProvider>
-      <AppSidebar />
+      <AppSidebar
+        activeSection={activeSection}
+        onSelectSection={setActiveSection}
+      />
       <SidebarInset>
         <header className="flex h-16 shrink-0 items-center gap-2 transition-[width,height] ease-linear group-has-data-[collapsible=icon]/sidebar-wrapper:h-12">
           <div className="flex items-center gap-2 px-4">
@@ -33,28 +53,59 @@ export default function Dashboard() {
               <BreadcrumbList>
                 <BreadcrumbItem className="hidden md:block">
                   <BreadcrumbLink href="#">
-                    Building Your Application
+                    Dashboard
                   </BreadcrumbLink>
                 </BreadcrumbItem>
                 <BreadcrumbSeparator className="hidden md:block" />
                 <BreadcrumbItem>
-                  <BreadcrumbPage>Data Fetching</BreadcrumbPage>
+                  <BreadcrumbPage>{breadcrumbLabel}</BreadcrumbPage>
                 </BreadcrumbItem>
               </BreadcrumbList>
             </Breadcrumb>
           </div>
         </header>
-        <div className="flex flex-1 flex-col gap-4 p-4 pt-0">
-          <div className="grid auto-rows-min gap-4 md:grid-cols-2">
-            <TableCategory />
-            <DataTableDemo />
-          </div>
-          <div className="bg-muted/50 min-h-[100vh] flex-1 rounded-xl md:min-h-min" />
-          <div className="grid auto-rows-min gap-4 md:grid-cols-3">
-            <div className="bg-muted/50 aspect-video rounded-xl" />
-            <div className="bg-muted/50 aspect-video rounded-xl" />
-            <div className="bg-muted/50 aspect-video rounded-xl" />
-          </div>
+        <div className="flex flex-1 flex-col gap-6 p-4 pt-0">
+          {activeSection === "products" && (
+            <section className="space-y-4">
+              <div>
+                <h1 className="text-2xl font-semibold tracking-tight">
+                  Lista de produtos
+                </h1>
+                <p className="text-muted-foreground text-sm">
+                  Consulte os itens cadastrados e realize ações rápidas.
+                </p>
+              </div>
+              <TableProducts />
+            </section>
+          )}
+
+          {activeSection === "categories" && (
+            <section className="space-y-4">
+              <div>
+                <h1 className="text-2xl font-semibold tracking-tight">
+                  Lista de categorias
+                </h1>
+                <p className="text-muted-foreground text-sm">
+                  Visualize as categorias disponíveis no cardápio.
+                </p>
+              </div>
+              <TableCategory />
+            </section>
+          )}
+
+          {activeSection === "ingredients" && (
+            <section className="space-y-4">
+              <div>
+                <h1 className="text-2xl font-semibold tracking-tight">
+                  Lista de ingredientes
+                </h1>
+                <p className="text-muted-foreground text-sm">
+                  Acompanhe os ingredientes e faça o controle de estoque.
+                </p>
+              </div>
+              <TableIngredients />
+            </section>
+          )}
         </div>
       </SidebarInset>
     </SidebarProvider>

--- a/dashboard-qrcode-menu/src/pages/home/index.tsx
+++ b/dashboard-qrcode-menu/src/pages/home/index.tsx
@@ -1,5 +1,3 @@
-import React from "react";
-
 export default function Home() {
   return (
     <div>


### PR DESCRIPTION
## Summary
- convert the sidebar menu into direct actions that switch between product, category, and ingredient lists
- add dedicated tables for products and ingredients while reusing the categories table when selected
- update the dashboard layout and breadcrumbs to surface the active section context

## Testing
- yarn build

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_691119ff130c83209e216b37069144e4)