### PR TITLE
Add category creation form with zod validation

### DIFF
--- a/dashboard-qrcode-menu/package.json
+++ b/dashboard-qrcode-menu/package.json
@@ -16,6 +16,7 @@
     "@radix-ui/react-collapsible": "^1.1.12",
     "@radix-ui/react-dialog": "^1.1.15",
     "@radix-ui/react-dropdown-menu": "^2.1.16",
+    "@radix-ui/react-label": "^2.1.8",
     "@radix-ui/react-separator": "^1.1.8",
     "@radix-ui/react-slot": "^1.2.4",
     "@radix-ui/react-tooltip": "^1.2.8",

--- a/dashboard-qrcode-menu/src/api/category.fecth.ts
+++ b/dashboard-qrcode-menu/src/api/category.fecth.ts
@@ -9,3 +9,10 @@ export const findAllCategory = async () => {
 
   return data;
 };
+
+export const createCategory = async (name: string, description: string) => {
+  const response = await api.post("/categories", { name, description });
+  const data: CategoryType = response.data;
+
+  return data;
+};

--- a/dashboard-qrcode-menu/src/components/ui/form.tsx
+++ b/dashboard-qrcode-menu/src/components/ui/form.tsx
@@ -1,0 +1,132 @@
+import * as React from "react";
+import * as LabelPrimitive from "@radix-ui/react-label";
+import { Slot } from "@radix-ui/react-slot";
+import { Controller, ControllerProps, FieldPath, FieldValues, FormProvider, useFormContext } from "react-hook-form";
+
+import { cn } from "@/lib/utils";
+
+const Form = FormProvider;
+
+interface FormFieldContextValue<TFieldValues extends FieldValues = FieldValues, TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>> {
+  name: TName;
+}
+
+const FormFieldContext = React.createContext<FormFieldContextValue>({} as FormFieldContextValue);
+
+const FormField = <TFieldValues extends FieldValues, TName extends FieldPath<TFieldValues>>({
+  ...props
+}: ControllerProps<TFieldValues, TName>) => {
+  return (
+    <FormFieldContext.Provider value={{ name: props.name }}>
+      <Controller {...props} />
+    </FormFieldContext.Provider>
+  );
+};
+
+const useFormField = () => {
+  const fieldContext = React.useContext(FormFieldContext);
+  const itemContext = React.useContext(FormItemContext);
+  const { getFieldState, formState } = useFormContext();
+
+  if (!fieldContext) {
+    throw new Error("useFormField should be used within <FormField>");
+  }
+
+  const fieldState = getFieldState(fieldContext.name, formState);
+
+  const id = itemContext?.id;
+
+  return {
+    id,
+    name: fieldContext.name,
+    formItemId: `${id}-form-item`,
+    formDescriptionId: `${id}-form-item-description`,
+    formMessageId: `${id}-form-item-message`,
+    ...fieldState,
+  };
+};
+
+interface FormItemContextValue {
+  id: string;
+}
+
+const FormItemContext = React.createContext<FormItemContextValue>({} as FormItemContextValue);
+
+const FormItem = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
+  ({ className, ...props }, ref) => {
+    const id = React.useId();
+
+    return (
+      <FormItemContext.Provider value={{ id }}>
+        <div ref={ref} className={cn("space-y-2", className)} {...props} />
+      </FormItemContext.Provider>
+    );
+  }
+);
+FormItem.displayName = "FormItem";
+
+const FormLabel = React.forwardRef<
+  React.ElementRef<typeof LabelPrimitive.Root>,
+  React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
+>(({ className, ...props }, ref) => {
+  const { error, formItemId } = useFormField();
+
+  return (
+    <LabelPrimitive.Root
+      ref={ref}
+      className={cn(error && "text-destructive", className)}
+      htmlFor={formItemId}
+      {...props}
+    />
+  );
+});
+FormLabel.displayName = "FormLabel";
+
+const FormControl = React.forwardRef<React.ElementRef<typeof Slot>, React.ComponentPropsWithoutRef<typeof Slot>>(
+  ({ ...props }, ref) => {
+    const { formItemId, formDescriptionId, formMessageId, error } = useFormField();
+
+    return (
+      <Slot
+        ref={ref}
+        id={formItemId}
+        aria-describedby={formDescriptionId}
+        aria-errormessage={error ? formMessageId : undefined}
+        aria-invalid={!!error}
+        {...props}
+      />
+    );
+  }
+);
+FormControl.displayName = "FormControl";
+
+const FormDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, ...props }, ref) => {
+    const { formDescriptionId } = useFormField();
+
+    return (
+      <p ref={ref} id={formDescriptionId} className={cn("text-[0.8rem] text-muted-foreground", className)} {...props} />
+    );
+  }
+);
+FormDescription.displayName = "FormDescription";
+
+const FormMessage = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
+  ({ className, children, ...props }, ref) => {
+    const { error, formMessageId } = useFormField();
+    const body = error ? String(error?.message) : children;
+
+    if (!body) {
+      return null;
+    }
+
+    return (
+      <p ref={ref} id={formMessageId} className={cn("text-[0.8rem] font-medium text-destructive", className)} {...props}>
+        {body}
+      </p>
+    );
+  }
+);
+FormMessage.displayName = "FormMessage";
+
+export { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage };

--- a/dashboard-qrcode-menu/src/components/ui/form.tsx
+++ b/dashboard-qrcode-menu/src/components/ui/form.tsx
@@ -1,132 +1,94 @@
+"use client";
+
 import * as React from "react";
 import * as LabelPrimitive from "@radix-ui/react-label";
 import { Slot } from "@radix-ui/react-slot";
-import { Controller, ControllerProps, FieldPath, FieldValues, FormProvider, useFormContext } from "react-hook-form";
+import {
+  Controller,
+  type FieldPath,
+  type FieldValues,
+  FormProvider,
+  useFormContext,
+} from "react-hook-form";
 
 import { cn } from "@/lib/utils";
 
 const Form = FormProvider;
 
-interface FormFieldContextValue<TFieldValues extends FieldValues = FieldValues, TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>> {
+interface FormFieldProps<
+  TFieldValues extends FieldValues = FieldValues,
+  TName extends FieldPath<TFieldValues> = FieldPath<TFieldValues>
+> {
   name: TName;
+  render: (props: {
+    field: ReturnType<typeof useFormContext<TFieldValues>>["register"];
+    fieldState: ReturnType<
+      typeof useFormContext<TFieldValues>
+    >["formState"]["errors"][TName];
+  }) => React.ReactNode;
 }
 
-const FormFieldContext = React.createContext<FormFieldContextValue>({} as FormFieldContextValue);
+function FormField<
+  TFieldValues extends FieldValues,
+  TName extends FieldPath<TFieldValues>
+>({ name, render }: FormFieldProps<TFieldValues, TName>) {
+  const { control } = useFormContext<TFieldValues>();
 
-const FormField = <TFieldValues extends FieldValues, TName extends FieldPath<TFieldValues>>({
-  ...props
-}: ControllerProps<TFieldValues, TName>) => {
   return (
-    <FormFieldContext.Provider value={{ name: props.name }}>
-      <Controller {...props} />
-    </FormFieldContext.Provider>
+    <Controller
+      control={control}
+      name={name}
+      render={({ field, fieldState }) => render({ field, fieldState })}
+    />
   );
-};
-
-const useFormField = () => {
-  const fieldContext = React.useContext(FormFieldContext);
-  const itemContext = React.useContext(FormItemContext);
-  const { getFieldState, formState } = useFormContext();
-
-  if (!fieldContext) {
-    throw new Error("useFormField should be used within <FormField>");
-  }
-
-  const fieldState = getFieldState(fieldContext.name, formState);
-
-  const id = itemContext?.id;
-
-  return {
-    id,
-    name: fieldContext.name,
-    formItemId: `${id}-form-item`,
-    formDescriptionId: `${id}-form-item-description`,
-    formMessageId: `${id}-form-item-message`,
-    ...fieldState,
-  };
-};
-
-interface FormItemContextValue {
-  id: string;
 }
 
-const FormItemContext = React.createContext<FormItemContextValue>({} as FormItemContextValue);
-
-const FormItem = React.forwardRef<HTMLDivElement, React.HTMLAttributes<HTMLDivElement>>(
-  ({ className, ...props }, ref) => {
-    const id = React.useId();
-
-    return (
-      <FormItemContext.Provider value={{ id }}>
-        <div ref={ref} className={cn("space-y-2", className)} {...props} />
-      </FormItemContext.Provider>
-    );
-  }
-);
+const FormItem = React.forwardRef<
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
+>(({ className, ...props }, ref) => (
+  <div ref={ref} className={cn("space-y-2", className)} {...props} />
+));
 FormItem.displayName = "FormItem";
 
 const FormLabel = React.forwardRef<
   React.ElementRef<typeof LabelPrimitive.Root>,
   React.ComponentPropsWithoutRef<typeof LabelPrimitive.Root>
->(({ className, ...props }, ref) => {
-  const { error, formItemId } = useFormField();
-
-  return (
-    <LabelPrimitive.Root
-      ref={ref}
-      className={cn(error && "text-destructive", className)}
-      htmlFor={formItemId}
-      {...props}
-    />
-  );
-});
+>(({ className, ...props }, ref) => (
+  <LabelPrimitive.Root
+    ref={ref}
+    className={cn("text-sm font-medium leading-none", className)}
+    {...props}
+  />
+));
 FormLabel.displayName = "FormLabel";
 
-const FormControl = React.forwardRef<React.ElementRef<typeof Slot>, React.ComponentPropsWithoutRef<typeof Slot>>(
-  ({ ...props }, ref) => {
-    const { formItemId, formDescriptionId, formMessageId, error } = useFormField();
-
-    return (
-      <Slot
-        ref={ref}
-        id={formItemId}
-        aria-describedby={formDescriptionId}
-        aria-errormessage={error ? formMessageId : undefined}
-        aria-invalid={!!error}
-        {...props}
-      />
-    );
-  }
-);
+const FormControl = React.forwardRef<
+  React.ElementRef<typeof Slot>,
+  React.ComponentPropsWithoutRef<typeof Slot>
+>(({ ...props }, ref) => <Slot ref={ref} {...props} />);
 FormControl.displayName = "FormControl";
 
-const FormDescription = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
-  ({ className, ...props }, ref) => {
-    const { formDescriptionId } = useFormField();
+const FormMessage = React.forwardRef<
+  HTMLParagraphElement,
+  React.HTMLAttributes<HTMLParagraphElement>
+>(({ className, children, ...props }, ref) => {
+  const body = children ? (
+    children
+  ) : (
+    <span className="text-sm text-destructive">Campo obrigatório</span>
+  );
 
-    return (
-      <p ref={ref} id={formDescriptionId} className={cn("text-[0.8rem] text-muted-foreground", className)} {...props} />
-    );
-  }
-);
-FormDescription.displayName = "FormDescription";
-
-const FormMessage = React.forwardRef<HTMLParagraphElement, React.HTMLAttributes<HTMLParagraphElement>>(
-  ({ className, children, ...props }, ref) => {
-    const { error, formMessageId } = useFormField();
-    const body = error ? String(error?.message) : children;
-
-    if (!body) {
-      return null;
-    }
-
-    return (
-      <p ref={ref} id={formMessageId} className={cn("text-[0.8rem] font-medium text-destructive", className)} {...props}>
-        {body}
-      </p>
-    );
-  }
-);
+  return (
+    <p
+      ref={ref}
+      className={cn("text-sm font-medium text-destructive", className)}
+      {...props}
+    >
+      {body}
+    </p>
+  );
+});
 FormMessage.displayName = "FormMessage";
 
-export { Form, FormControl, FormDescription, FormField, FormItem, FormLabel, FormMessage };
+export { Form, FormField, FormItem, FormLabel, FormControl, FormMessage };

--- a/dashboard-qrcode-menu/src/pages/categories/index.tsx
+++ b/dashboard-qrcode-menu/src/pages/categories/index.tsx
@@ -1,8 +1,56 @@
+import { useMutation } from "@tanstack/react-query";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { useForm } from "react-hook-form";
+import { z } from "zod";
+
+import { api } from "@/api";
 import { TableCategory } from "@/components/table-categories";
+import { Button } from "@/components/ui/button";
+import {
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+
+const categorySchema = z.object({
+  name: z.string().min(1, "Informe o nome da categoria."),
+  description: z
+    .string()
+    .min(1, "Informe uma descrição para a categoria.")
+    .max(200, "A descrição deve conter no máximo 200 caracteres."),
+});
+
+type CategoryFormValues = z.infer<typeof categorySchema>;
 
 export default function Categories() {
+  const form = useForm<CategoryFormValues>({
+    resolver: zodResolver(categorySchema),
+    defaultValues: {
+      name: "",
+      description: "",
+    },
+  });
+
+  const createCategoryMutation = useMutation({
+    mutationFn: async (values: CategoryFormValues) => {
+      const response = await api.post("/categories", values);
+      return response.data;
+    },
+    onSuccess: () => {
+      form.reset();
+    },
+  });
+
+  const onSubmit = (values: CategoryFormValues) => {
+    createCategoryMutation.mutate(values);
+  };
+
   return (
-    <section className="space-y-4">
+    <section className="space-y-6">
       <div>
         <h1 className="text-2xl font-semibold tracking-tight">
           Lista de categorias
@@ -10,6 +58,73 @@ export default function Categories() {
         <p className="text-muted-foreground text-sm">
           Visualize as categorias disponíveis no cardápio.
         </p>
+      </div>
+      <div className="rounded-lg border bg-card p-6 shadow-sm">
+        <div className="mb-6 space-y-1">
+          <h2 className="text-lg font-semibold">Cadastrar categoria</h2>
+          <p className="text-sm text-muted-foreground">
+            Informe os dados abaixo para criar uma nova categoria.
+          </p>
+        </div>
+        <Form {...form}>
+          <form
+            onSubmit={form.handleSubmit(onSubmit)}
+            className="grid gap-4 md:grid-cols-2"
+          >
+            <FormField
+              control={form.control}
+              name="name"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Nome</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="Bebidas"
+                      autoComplete="off"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <FormField
+              control={form.control}
+              name="description"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Descrição</FormLabel>
+                  <FormControl>
+                    <Input
+                      placeholder="Descrição da categoria"
+                      autoComplete="off"
+                      {...field}
+                    />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+            <div className="md:col-span-2 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+              <div className="flex-1 text-sm text-muted-foreground">
+                Campos marcados são obrigatórios.
+              </div>
+              <Button type="submit" disabled={createCategoryMutation.isPending}>
+                {createCategoryMutation.isPending ? "Salvando..." : "Salvar categoria"}
+              </Button>
+            </div>
+            {createCategoryMutation.isError ? (
+              <p className="md:col-span-2 text-sm text-destructive">
+                Não foi possível criar a categoria. Tente novamente.
+              </p>
+            ) : null}
+            {createCategoryMutation.isSuccess ? (
+              <p className="md:col-span-2 text-sm text-emerald-600">
+                Categoria criada com sucesso!
+              </p>
+            ) : null}
+          </form>
+        </Form>
       </div>
       <TableCategory />
     </section>

--- a/dashboard-qrcode-menu/src/pages/categories/index.tsx
+++ b/dashboard-qrcode-menu/src/pages/categories/index.tsx
@@ -72,14 +72,13 @@ export default function Categories() {
             className="grid gap-4 md:grid-cols-2"
           >
             <FormField
-              control={form.control}
               name="name"
               render={({ field }) => (
                 <FormItem>
                   <FormLabel>Nome</FormLabel>
                   <FormControl>
                     <Input
-                      placeholder="Bebidas"
+                      placeholder="Insira o nome da categoria"
                       autoComplete="off"
                       {...field}
                     />
@@ -88,8 +87,8 @@ export default function Categories() {
                 </FormItem>
               )}
             />
+
             <FormField
-              control={form.control}
               name="description"
               render={({ field }) => (
                 <FormItem>
@@ -105,24 +104,33 @@ export default function Categories() {
                 </FormItem>
               )}
             />
+
             <div className="md:col-span-2 flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
               <div className="flex-1 text-sm text-muted-foreground">
                 Campos marcados são obrigatórios.
               </div>
-              <Button type="submit" disabled={createCategoryMutation.isPending}>
-                {createCategoryMutation.isPending ? "Salvando..." : "Salvar categoria"}
+              <Button
+                className="cursor-pointer"
+                type="submit"
+                disabled={createCategoryMutation.isPending}
+              >
+                {createCategoryMutation.isPending
+                  ? "Salvando..."
+                  : "Salvar categoria"}
               </Button>
             </div>
-            {createCategoryMutation.isError ? (
+
+            {createCategoryMutation.isError && (
               <p className="md:col-span-2 text-sm text-destructive">
                 Não foi possível criar a categoria. Tente novamente.
               </p>
-            ) : null}
-            {createCategoryMutation.isSuccess ? (
+            )}
+
+            {createCategoryMutation.isSuccess && (
               <p className="md:col-span-2 text-sm text-emerald-600">
                 Categoria criada com sucesso!
               </p>
-            ) : null}
+            )}
           </form>
         </Form>
       </div>

--- a/dashboard-qrcode-menu/yarn.lock
+++ b/dashboard-qrcode-menu/yarn.lock
@@ -527,6 +527,13 @@
   dependencies:
     "@radix-ui/react-use-layout-effect" "1.1.1"
 
+"@radix-ui/react-label@^2.1.8":
+  version "2.1.8"
+  resolved "https://registry.yarnpkg.com/@radix-ui/react-label/-/react-label-2.1.8.tgz#d93b7c063ef2ea034df143a2464bfc0548e4b7e5"
+  integrity sha512-FmXs37I6hSBVDlO4y764TNz1rLgKwjJMQ0EGte6F3Cb3f4bIuHB/iLa/8I9VKkmOy+gNHq8rql3j686ACVV21A==
+  dependencies:
+    "@radix-ui/react-primitive" "2.1.4"
+
 "@radix-ui/react-menu@2.1.16":
   version "2.1.16"
   resolved "https://registry.yarnpkg.com/@radix-ui/react-menu/-/react-menu-2.1.16.tgz#528a5a973c3a7413d3d49eb9ccd229aa52402911"


### PR DESCRIPTION
## Summary
- add reusable shadcn-style form primitives for react-hook-form integration
- implement category creation form that validates with zod and submits via axios mutation

## Testing
- npm run lint *(fails: existing lint errors in unrelated files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911dc0ffb24832088fb3e4d08cc8dcb)