### PR TITLE
feat: allow editing categories from selection

### DIFF
--- a/frontend-qrcode-menu/src/app/dashboard/category/columns.tsx
+++ b/frontend-qrcode-menu/src/app/dashboard/category/columns.tsx
@@ -6,8 +6,34 @@ import { ColumnDef } from "@tanstack/react-table";
 
 export const getColumnsCategory = (
   onEdit: (categoryId: string, data: { name: string }) => void,
-  onDelete: (id: string) => void
+  onDelete: (id: string) => void,
+  onSelect: (category: CategoryType) => void,
+  selectedCategoryId: string | null
 ): ColumnDef<CategoryType>[] => [
+  {
+    id: "select",
+    header: () => <div className="text-center w-full">Selecionar</div>,
+    cell: ({ row }) => {
+      const category = row.original;
+      return (
+        <div className="flex justify-center">
+          <input
+            type="radio"
+            name="categorySelect"
+            value={category.id}
+            checked={selectedCategoryId === category.id}
+            onChange={(event) => {
+              if (event.target.checked) {
+                onSelect(category);
+              }
+            }}
+            className="cursor-pointer"
+            aria-label={`Selecionar categoria ${category.name}`}
+          />
+        </div>
+      );
+    },
+  },
   {
     accessorKey: "name",
     header: () => <div className="text-center w-full">Nome</div>,

--- a/frontend-qrcode-menu/src/app/dashboard/category/page.tsx
+++ b/frontend-qrcode-menu/src/app/dashboard/category/page.tsx
@@ -1,15 +1,37 @@
+"use client";
+
 import FormCategory from "@/components/FormCategory";
 import TableCategories from "@/components/TableCategories";
-import React from "react";
+import { useCallback, useState } from "react";
+import { CategoryType } from "@/types/category.type";
 
 export default function PageCategory() {
+  const [selectedCategory, setSelectedCategory] = useState<CategoryType | null>(
+    null
+  );
+
+  const handleSelectCategory = useCallback((category: CategoryType) => {
+    setSelectedCategory(category);
+  }, []);
+
+  const handleClearSelection = useCallback(() => {
+    setSelectedCategory(null);
+  }, []);
+
   return (
     <div className="bg-white rounded-lg shadow-sm border border-gray-200 p-8 w-full">
       <h3 className="text-lg font-medium text-gray-900 mb-4">
         Bem-vindo a Category
       </h3>
-      <FormCategory />
-      <TableCategories />
+      <FormCategory
+        selectedCategory={selectedCategory}
+        onClearSelection={handleClearSelection}
+      />
+      <TableCategories
+        onSelectCategory={handleSelectCategory}
+        selectedCategoryId={selectedCategory?.id ?? null}
+        onClearSelection={handleClearSelection}
+      />
     </div>
   );
 }

--- a/frontend-qrcode-menu/src/components/TableCategories.tsx
+++ b/frontend-qrcode-menu/src/components/TableCategories.tsx
@@ -10,10 +10,19 @@ import { getColumnsCategory } from "@/app/dashboard/category/columns";
 import { DataTable } from "@/app/dashboard/category/data-table";
 import { CategoryType } from "@/types/category.type";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import React from "react";
 import { toast } from "sonner";
 
-export default function TableCategories() {
+interface TableCategoriesProps {
+  onSelectCategory: (category: CategoryType) => void;
+  selectedCategoryId: string | null;
+  onClearSelection: () => void;
+}
+
+export default function TableCategories({
+  onSelectCategory,
+  selectedCategoryId,
+  onClearSelection,
+}: TableCategoriesProps) {
   const queryClient = useQueryClient();
   const {
     data,
@@ -26,7 +35,10 @@ export default function TableCategories() {
 
   const deleteMutation = useMutation({
     mutationFn: deleteCategory,
-    onSuccess: () => {
+    onSuccess: (_, deletedId) => {
+      if (selectedCategoryId === deletedId) {
+        onClearSelection();
+      }
       queryClient.invalidateQueries({ queryKey: ["categories"] });
     },
     onError: (error: any) => {
@@ -68,7 +80,12 @@ export default function TableCategories() {
 
   return (
     <DataTable
-      columns={getColumnsCategory(handleEdit, handleDelete)}
+      columns={getColumnsCategory(
+        handleEdit,
+        handleDelete,
+        onSelectCategory,
+        selectedCategoryId
+      )}
       data={data ?? []}
     />
   );


### PR DESCRIPTION
## Summary
- add a selection column to the category table so a row can feed the edit form
- update the category form to preload selected data, submit updates, and change the button label while editing
- lift the selected category state to the page to coordinate the table and form, clearing the selection after deletes or updates

## Testing
- npm run lint *(fails: existing lint issues in unrelated files)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6911e8136fe48320879988436d6119f0)