### PR TITLE
Document Dependabot audit limitation

### DIFF
--- a/DEPENDABOT_CHECK.md
+++ b/DEPENDABOT_CHECK.md
@@ -1,0 +1,9 @@
+# Dependabot security check
+
+Attempts were made to verify Dependabot security alerts locally:
+
+- `npm audit --audit-level=high` and `npm audit --audit-level=critical` were run in `backend-qrcode-menu`, but the npm security advisory API returned HTTP 403 errors (forbidden), preventing vulnerability details from being fetched.
+- `yarn npm audit --severity high` was also attempted, but it failed with HTTP 403 responses when contacting the npm registry.
+- The repository currently has no local Dependabot alert records or configuration files to inspect, so no additional alert data was available offline.
+
+Because registry access is blocked by the environment, I could not retrieve Dependabot or npm advisory data to confirm whether critical vulnerabilities exist. Re-running the audits in an environment with registry access is required to obtain the latest advisories and apply any necessary patches.


### PR DESCRIPTION
## Summary
- add DEPENDABOT_CHECK.md describing attempted security audit steps
- note that npm registry access is blocked, preventing retrieval of Dependabot advisories

## Testing
- not run (documentation-only change)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69415c38ddc8832090b3630cf4d8c613)